### PR TITLE
ea/776_779

### DIFF
--- a/tark/tark_web/templates/mane_data_access.html
+++ b/tark/tark_web/templates/mane_data_access.html
@@ -24,7 +24,12 @@
                     <span class="glyphicon glyphicon-info-sign"></span>
                     Note: We will have several data releases as we make progress on completing the MANE projects.
                 </div>
+                <!-- Browse list on access mane data to be above Bulk data download -->
+                <h3><span class="glyphicon glyphicon-search" style="top: 4px"></span>&nbsp;Browse list</h3>
 
+                <p>Browse or export a list of all MANE transcripts in <a class="icon-external-link"
+                                                                         href="/web/manelist/">Tark</a>.</p>   
+                
                 <h3><span class="glyphicon glyphicon-download-alt" style="top: 4px"></span>&nbsp;Bulk data download</h3>
 
                 <p>The full MANE transcript datasets can be downloaded via:</p>
@@ -60,11 +65,11 @@
                     </li>
                 </ul>
 
-
-                <h3><span class="glyphicon glyphicon-search" style="top: 4px"></span>&nbsp;Browse list</h3>
+                <!-- Comment duplicate browse list section -->
+                <!-- <h3><span class="glyphicon glyphicon-search" style="top: 4px"></span>&nbsp;Browse list</h3>
 
                 <p>Browse or export a list of all MANE transcripts in <a class="icon-external-link"
-                                                                         href="/web/manelist/">Tark</a>.</p>
+                                                                         href="/web/manelist/">Tark</a>.</p> -->
 
 
                 <h3><span class="glyphicon glyphicon-wrench" style="top: 4px"></span>&nbsp;Web services</h3>

--- a/tark/tark_web/templates/search_result.html
+++ b/tark/tark_web/templates/search_result.html
@@ -374,7 +374,8 @@ $(document).ready(function() {
             });          
         },
      
-    "order": [[ 11, "desc" ], [ 4, "desc" ], [ 6, "desc" ]],
+    /* change order to Type desc,  Source asc, Strand desc, Assembly desc, From release desc*/
+    "order": [[ 14, "desc" ], [ 5, "asc" ], [ 11, "desc" ], [ 4, "desc" ], [ 6, "desc" ]],
     "columnDefs": [ {
       "targets"  : 'no-sort',
       "orderable": false,


### PR DESCRIPTION
Two code fixes:
1. EA-776 - MANE transcripts to be the top of the transcript search results
2. EA-779 - Browse list on access mane data to be above Bulk data download
Steps to reproduce the issues mentioned in the commit comments of individual files. Two files modified in this branch