### PR TITLE
EA - 752 - Update TARK link to https

### DIFF
--- a/tark/tark/templates/rest_framework_swagger/base.html
+++ b/tark/tark/templates/rest_framework_swagger/base.html
@@ -97,6 +97,15 @@
 </script>
 
 <script src='{% static "rest_framework_swagger/init.js" %}' type='text/javascript'></script>
+<!--Add meta tag to upgrade insecure requests -->
+<script>
+  if (window.location.protocol.indexOf('https') == 0){
+    var el = document.createElement('meta')
+    el.setAttribute('http-equiv', 'Content-Security-Policy')
+    el.setAttribute('content', 'upgrade-insecure-requests')
+    document.head.append(el)
+  }
+</script>
 {% block extra_scripts %}
 {# -- Add any additional custom JS scripts here -- #}
 {% endblock %}


### PR DESCRIPTION
Issue:  api search from [https link](https://dev-tark.ensembl.org/api) returns error.
Fix: upgrade insecure requests
Result: api search works from both [https](https://dev-tark.ensembl.org/api) and [http](http://dev-tark.ensembl.org/api)