### PR TITLE
Ea/mane

### DIFF
--- a/tark/release/models.py
+++ b/tark/release/models.py
@@ -74,6 +74,8 @@ class ReleaseStats(models.Model):
         managed = False
         db_table = 'release_stats'
         # unique_together = (('release'),)
+        # display most recent release at top of the table
+        ordering = ['-release_stats_id']
 
 
 class GeneReleaseTag(models.Model):

--- a/tark/tark_web/templates/datatable_view_release_set.html
+++ b/tark/tark_web/templates/datatable_view_release_set.html
@@ -72,6 +72,7 @@ $(document).ready(function() {
 	 $('#loadingSpinner').hide();
      $release_set_datatable =  $('#release_set_datatable').DataTable( {
         "pageLength": 25,
+	"order":[[ 0, "asc" ],[3, "desc" ], [2, "desc" ]],
         ajax: {
         url: "/api/release/nopagination",
         dataSrc: '' 

--- a/tark/tark_web/templates/maneGRCh37_list.html
+++ b/tark/tark_web/templates/maneGRCh37_list.html
@@ -1,0 +1,152 @@
+{% extends "web_home.html" %}
+
+{% load staticfiles %}
+{% load add_class %}
+{% load add_class %}
+{% load search_result_formatter %}
+
+{% block content %}
+
+<div class="container" style="padding-top:20px;">
+
+<!-- Info -->
+<div class="panel panel-success">
+  <div class="panel-heading"><i class="glyphicon glyphicon-info-sign"></i> <strong><a href="https://ncbiinsights.ncbi.nlm.nih.gov/2018/10/11/matched-annotation-by-ncbi-and-embl-ebi-mane-a-new-joint-venture-to-define-a-set-of-representative-transcripts-for-human-protein-coding-genes/" target="_blank">MANE</a> Transcripts</strong>
+  Note: "<strong>MANE Select</strong>" – representative transcripts that are matched between RefSeq and Ensembl</div>
+  <div class="panel-body">
+
+  <table id="mane_table" class="table table-striped table-bordered table-responsive table-condensed text-center">
+ <thead>
+  <tr>
+     <th>Gene</th>
+     <th>MANE TYPE</th>
+     <th>Ensembl StableID</th>
+     <th>RefSeq StableID</th>
+     <th>GRCh37</th>
+     <th>5'UTR</th>
+     <th>CDS</th>
+     <th>3'UTR</th>
+
+  </tr>
+ </thead>
+ <tbody>
+
+ </tbody>
+ </table>
+
+ </div>
+ </div>
+ </div>
+
+
+
+<script>
+      $(document).ready(function() {
+      $('[data-toggle="tooltip"]').tooltip();
+          var table = $('#mane_table').DataTable({
+                       dom: 'lBfrtip',
+                      "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]],
+                      "pageLength": 10,
+                      "buttons": [
+                       { extend: 'copy', text: 'COPY', exportOptions: { columns: ':visible', rows: ':visible'}},
+                       { extend: 'csv', text: 'CSV', exportOptions: { columns: ':visible', rows: ':visible' }},
+                       { extend: 'excel', text: 'Excel', exportOptions: { columns: ':visible', rows: ':visible' }},
+                       { extend: 'pdf', text: 'PDF', exportOptions:{ columns: ':visible', rows: ':visible' }},
+                        'colvis'
+                       ],
+              "deferRender": true,
+              "language": {
+              "search": "<strong>Filter results:</strong> "
+               },
+              "pageLength": 25,
+              "order": [[ 0, "asc" ]],
+              "processing": true,
+              //"serverSide": true,
+              //"serverpagination": false,
+              "ajax": {
+                 "processing": true,
+                 "url": "/api/transcript/maneGRCh37list/?format=json",
+                 "dataSrc": ""
+             },
+              "columns": [
+                 { "mData": "ens_gene_name",
+                   "className": "text-left",
+                           "mRender": function ( data, type, row ) {
+                                return "<a href='/web/search/?identifier=" + row['ens_gene_name'] + "' target='_blank'>" + row['ens_gene_name'] + "</a>";
+                         }
+                                },
+                { "mData": "mane_type",
+                   "className": "text-left",
+                           "mRender": function ( data, type, row ) {
+                                return row['mane_type'];
+                         }
+                                },
+
+                  { "mData": "ens_stable_id",
+                     "className": "text-left",
+                           "mRender": function ( data, type, row ) {
+                                ens_id = row["ens_stable_id"] + '.' + row["ens_stable_id_version"];
+                                ens_link = "<a href='http://ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t=" + ens_id + "' target='_blank'>" + ens_id + "</a>";
+                                return ens_link;
+                         }
+                                },
+                 { "mData": "refseq_stable_id",
+                   "className": "text-left",
+                           "mRender": function ( data, type, row ) {
+                                refseq_id = row["refseq_stable_id"] + '.' + row["refseq_stable_id_version"];
+                                refseq_link = "<a href=' https://www.ncbi.nlm.nih.gov/nuccore/" + refseq_id + "' target='_blank'>" + refseq_id + "</a>";
+                                return refseq_link;
+                         }
+                                },
+
+                 { "mData": "grch37_stable_id",
+                   "className": "text-left",
+                           "mRender": function ( data, type, row ) {
+                                 grch37_id = row["grch37_stable_id"] + '.' + row["grch37_stable_id_version"];
+                                 grch37_link = "<a href='http://ensembl.org/Homo_sapiens/Transcript/Summary?db=core;t=" + grch37_id + "' target='_blank'>" + grch37_id + "</a>";
+                                 return grch37_link;
+                         }
+                                } ,
+
+                { "mData": "five_prime_utr",
+                   "className": "text-left",
+                           "mRender": function ( data, type, row) {
+                                  if (row['five_prime_utr'] == '') {
+                                     five_prime_utr_match ='<i class="glyphicon glyphicon-remove text-center"  style="color:red"></i>'
+                                  } else {
+                                     five_prime_utr_match ='<i class="glyphicon glyphicon-ok text-center"  style="color:green"></i>'
+                                   }
+                                return five_prime_utr_match;
+                         }
+                                },
+                { "mData": "cds",
+                   "className": "text-left",
+                           "mRender": function ( data, type, row ) {
+                             if (row['cds'] == '') {
+                                cds_match = '<i class="glyphicon glyphicon-remove text-center"  style="color:red"></i>'
+                             } else {
+                                cds_match ='<i class="glyphicon glyphicon-ok text-center"  style="color:green"></i>'
+                            }
+                            return cds_match;
+                         }
+                                },
+
+                { "mData": "three_prime_utr",
+                   "className": "text-left",
+                           "mRender": function ( data, type, row ) {
+                                if (row['three_prime_utr'] == '') {
+                                     three_prime_utr_match ='<i class="glyphicon glyphicon-remove text-center"  style="color:red"></i>'
+                                } else {
+                                     three_prime_utr_match ='<i class="glyphicon glyphicon-ok text-center"  style="color:green"></i>'
+                                }
+                                return three_prime_utr_match;
+                         }
+                                }
+
+
+              ]
+          });
+      });
+  </script>
+
+{% endblock %}

--- a/tark/tark_web/templates/mane_breadcrumbs.html
+++ b/tark/tark_web/templates/mane_breadcrumbs.html
@@ -1,6 +1,6 @@
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/web/mane_project/">MANE Project</a></li>
+        <li class="breadcrumb-item"><a href="/web/mane_project/">MANE Collaboration</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ current_page }}</li>
     </ol>
 </nav>

--- a/tark/tark_web/templates/mane_collaboration_about.html
+++ b/tark/tark_web/templates/mane_collaboration_about.html
@@ -17,11 +17,11 @@
 
                 <h1>About the MANE Collaboration</h1>
 
-                <p>The MANE project - The Matched Annotation from the National Center for Biotechnology Information (<a
+                <p>The Matched Annotation from the National Center for Biotechnology Information (<a
                         class="icon-external-link" href="https://www.ncbi.nlm.nih.gov/" target="_blank">NCBI</a>) and
                     the European Molecular Biology Laboratories - European Bioinformatics Institute (<a
                             class="icon-external-link" href="https://www.ebi.ac.uk/" target="_blank">EMBL-EBI</a>)
-                    (MANE) is a collaborative project that aims to converge on human gene annotation to produce a genome
+                    (MANE) is a collaboration that aims to converge on human gene annotation and to produce a genome
                     wide transcript set that:</p>
                 <ul>
                     <li>
@@ -107,7 +107,7 @@
                         MANE.
                     </li>
                     <li> Collaboration with, and feedback from, the clinical community is an important aspect of the
-                        MANE projects. Transcripts of clinical interest not included in our MANE sets will be considered
+                        MANE Collaboration. Transcripts of clinical interest not included in our MANE sets will be considered
                         upon request and in consultation with expert clinical scientists. Contact us via <a
                                 href="mailto:mane-help@ebi.ac.uk">mane-help@ebi.ac.uk</a>.
                     </li>

--- a/tark/tark_web/templates/mane_data_access.html
+++ b/tark/tark_web/templates/mane_data_access.html
@@ -30,6 +30,9 @@
                 <p>Browse or export a list of all MANE transcripts in <a class="icon-external-link"
                                                                          href="/web/manelist/">Tark</a>.</p>   
                 
+                <!-- Provide link to new mane transcript CDS & UTR comparison page --> 
+                <p>Browse a list of all MANE transcripts and their counterparts on GRCh37 which have matching CDS and UTRs in <a class="icon-external-link" 
+                                                                                                                                 href="/web/maneGRCh37list/">Tark</a>.</p>
                 <h3><span class="glyphicon glyphicon-download-alt" style="top: 4px"></span>&nbsp;Bulk data download</h3>
 
                 <p>The full MANE transcript datasets can be downloaded via:</p>

--- a/tark/tark_web/templates/mane_list.html
+++ b/tark/tark_web/templates/mane_list.html
@@ -50,6 +50,7 @@
 		       { extend: 'pdf', text: 'PDF', exportOptions:{ columns: ':visible', rows: ':visible' }}, 
 		        'colvis'
 		       ],
+	      "deferRender": true,
               "language": {
               "search": "<strong>Filter results:</strong> "
                },

--- a/tark/tark_web/templates/mane_project.html
+++ b/tark/tark_web/templates/mane_project.html
@@ -14,7 +14,6 @@
         <div class="intro">
             <p>The <span class="bold_font">M</span>atched <span class="bold_font">A</span>nnotation from <span
                     class="bold_font">N</span>CBI and <span class="bold_font">E</span>MBL-EBI (<span class="bold_font">MANE</span>)
-                project
                 is a collaboration that aims to converge on human gene annotation and to produce a genome wide
                 transcript set that includes pairs of RefSeq (NM) and Ensembl/GENCODE (ENST) transcripts that are 100%
                 identical.</p>
@@ -60,7 +59,7 @@
 
                 <div class="heading-pt">
                     <div class="glyph-container"><span class="glyphicon glyphicon-record"></span></div>
-                    <div class="text-container">MANE project outputs</div>
+                    <div class="text-container">MANE Collaboration outputs</div>
                 </div>
 
                 <h4>MANE Select</h4>
@@ -80,7 +79,7 @@
 
                 <div class="heading-pt">
                     <div class="glyph-container"><span class="glyphicon glyphicon-record"></span></div>
-                    <div class="text-container">What is unique about the MANE project?</div>
+                    <div class="text-container">What is unique about the MANE Collaboration?</div>
                 </div>
 
                 <h4>Highest quality annotation</h4>

--- a/tark/tark_web/templates/navbar_include.html
+++ b/tark/tark_web/templates/navbar_include.html
@@ -10,7 +10,7 @@
       <li class="navbar-separator">|</li>
       <li class="navbar-item"><a href="/web/statistics/">ReleaseStats</a></li>
       <li class="navbar-separator">|</li>
-      <li class="navbar-item"><a href="/web/mane_project/">MANE Project</a></li>
+      <li class="navbar-item"><a href="/web/mane_project/">MANE Collaboration</a></li>
       <li class="navbar-separator">|</li>
       <li class="navbar-item"><a href="/web/search/"> Search & Compare </a></li>
      <li class="navbar-separator">|</li>

--- a/tark/tark_web/urls.py
+++ b/tark/tark_web/urls.py
@@ -137,6 +137,13 @@ urlpatterns = [
     ),
 
     url(
+        r'^maneGRCh37list/$',
+        TemplateView.as_view(
+            template_name='maneGRCh37_list.html'
+        )
+    ),
+   
+    url(
         r'^mane_project/$',
         TemplateView.as_view(
             template_name='mane_project.html'

--- a/tark/transcript/drf/serializers.py
+++ b/tark/transcript/drf/serializers.py
@@ -70,6 +70,18 @@ class TranscriptManeSerializer(serializers.Serializer):
     mane_type = serializers.CharField()
     ens_gene_name = serializers.CharField()
 
+class TranscriptManeGRCh37Serializer(serializers.Serializer):
+    ens_stable_id = serializers.CharField()
+    ens_stable_id_version = serializers.CharField()
+    refseq_stable_id = serializers.CharField()
+    refseq_stable_id_version = serializers.CharField()
+    mane_type = serializers.CharField()
+    ens_gene_name = serializers.CharField()
+    grch37_stable_id = serializers.CharField()
+    grch37_stable_id_version = serializers.CharField()
+    five_prime_utr = serializers.BooleanField()
+    cds = serializers.BooleanField()
+    three_prime_utr = serializers.BooleanField()
 
 class TranscriptSerializer(SerializerMixin, serializers.ModelSerializer):
 

--- a/tark/transcript/models.py
+++ b/tark/transcript/models.py
@@ -147,6 +147,55 @@ class Transcript(models.Model):
             return mane_transcripts
 
 
+    @classmethod
+    def fetch_mane_transcript_and_GRCh37(cls, transcript_id=None):
+
+        transcript = None
+        source = "Ensembl"
+        if transcript_id is not None:
+            transcript = Transcript.objects.get(pk=transcript_id)
+
+        if transcript is not None:
+            try:
+                source = transcript.transcript_release_set.all()[:1].get().source.shortname
+            except Exception as e:
+                logger.error("Exception from  get_mane_transcript " + str(e))
+
+        raw_sql = "SELECT DISTINCT\
+                        t1.transcript_id, t1.stable_id as ens_stable_id, t1.stable_id_version as ens_stable_id_version,\
+                        relationship_type.shortname as mane_type,\
+                        t2.stable_id as refseq_stable_id, t2.stable_id_version as refseq_stable_id_version,\
+                        gn1.name as ens_gene_name, \
+                        t3.stable_id as grch37_stable_id, t3.stable_id_version as grch37_stable_id_version,\
+                        IF(tl3.five_utr_checksum = tl1.five_utr_checksum,'True','False') as five_prime_utr,\
+                        'True' as cds,\
+                        IF(tl3.three_utr_checksum = tl1.three_utr_checksum,'True','False') as  three_prime_utr \
+                        FROM \
+                        transcript t1 \
+                        JOIN transcript_release_tag trt1 ON t1.transcript_id=trt1.feature_id \
+                        JOIN transcript_release_tag_relationship ON \
+                        trt1.transcript_release_id=transcript_release_tag_relationship.transcript_release_object_id \
+                        JOIN transcript_release_tag trt2 ON \
+                        transcript_release_tag_relationship.transcript_release_subject_id=trt2.transcript_release_id \
+                        JOIN transcript t2 ON trt2.feature_id=t2.transcript_id \
+                        JOIN relationship_type ON \
+                        transcript_release_tag_relationship.relationship_type_id=relationship_type.relationship_type_id\
+                        JOIN transcript_gene tg1 ON \
+                        t1.transcript_id=tg1.transcript_id \
+                        JOIN gene gene1 ON \
+                        tg1.gene_id=gene1.gene_id \
+                        JOIN gene_names gn1 ON \
+                        gene1.name_id=gn1.external_id and gn1.primary_id=1\
+                        JOIN transcript t3 ON t3.stable_id = t1.stable_id \
+                        AND t3.assembly_id = 1\
+                        JOIN  translation_transcript tt1 ON tt1.transcript_id = t1.transcript_id\
+                        JOIN translation tl1 ON tl1.translation_id = tt1.translation_id\
+                        JOIN translation_transcript tt3 ON tt3.transcript_id = t3.transcript_id\
+                        JOIN translation tl3 ON tl3.translation_id = tt3.translation_id\
+                        where t1.assembly_id = 1001 and tl3.seq_checksum = tl1.seq_checksum "
+        mane_transcripts = Transcript.objects.raw(raw_sql)
+        return mane_transcripts
+   
 class TranscriptGene(models.Model):
     gene_transcript_id = models.AutoField(primary_key=True)
     gene = models.ForeignKey(Gene, models.DO_NOTHING, blank=True, null=True)

--- a/tark/transcript/urls.py
+++ b/tark/transcript/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     url(r'^search/$', views.TranscriptSearch.as_view(), name='transcript_search'),
     url(r'^stable_id_with_version/$', views.TranscriptDetail.as_view(), name='transcript_detail'),
     url(r'^manelist/$', views.TranscriptManeList.as_view(), name='transcript_mane_list'),
+    url(r'^maneGRCh37list/$', views.TranscriptManeGRCh37List.as_view(), name='transcript_maneGRCh37_list'),
     # url(r'^mane/$', release_views.TranscriptReleaseTagRelationshipList.as_view(), name='transcript_mane')
 
 

--- a/tark/transcript/views.py
+++ b/tark/transcript/views.py
@@ -22,7 +22,7 @@ from tark_drf.utils.decorators import setup_eager_loading, expand_all_related
 from transcript.models import Transcript
 from transcript.drf.serializers import TranscriptSerializer,\
     TranscriptDiffSerializer, TranscriptSearchSerializer,\
-    TranscriptDataTableSerializer, TranscriptManeSerializer
+    TranscriptDataTableSerializer, TranscriptManeSerializer, TranscriptManeGRCh37Serializer
 from transcript.drf.filters import TranscriptFilterBackend,\
     TranscriptDiffFilterBackend, TranscriptSearchFilterBackend, TranscriptDetailFilterBackend
 from tark.utils.diff_utils import DiffUtils
@@ -57,6 +57,13 @@ class TranscriptManeList(generics.ListAPIView):
         queryset = Transcript.fetch_mane_transcript_and_type()
         return queryset
 
+class TranscriptManeGRCh37List(generics.ListAPIView):
+    serializer_class = TranscriptManeGRCh37Serializer
+    pagination_class = NotPaginatedSetPagination
+
+    def get_queryset(self):
+        queryset = Transcript.fetch_mane_transcript_and_GRCh37()
+        return queryset
 
 class TranscriptList(generics.ListAPIView):
     queryset = Transcript.objects.all()


### PR DESCRIPTION
PR related to 4 MANE tickets.

1. ea-742 - speed up mane:
Files modified: /tark/tark_web/templates/mane_list.html
Dev link: https://dev-tark.ensembl.org/web/manelist/

2. ea-780 mane transcript CDS & UTR comparison
Files modified: 
        /tark/tark_web/templates/mane_data_access.html
        /tark/tark_web/templates/maneGRCh37_list.html
        /tark/tark_web/urls.py        
        /tark/transcript/drf/serializers.py 
        /tark/transcript/urls.py 
        /tark/transcript/views.py        
        /tark/transcript/models.py
One time Script to load UTR checksums in translation table: Refer [confluence page](https://www.ebi.ac.uk/seqdb/confluence/display/EA/One+time+script+to+load+5%27+and+3%27+UTR+checksum+in+translation+table)
Dev link: https://dev-tark.ensembl.org/web/maneGRCh37list/
       
3. EA-805 - text on the MANE pages in Tark to be updated from MANE project to MANE collaboration
Files modified:    
         /tark/tark_web/templates/mane_collaboration_about.html
         /tark/tark_web/templates/mane_breadcrumbs.html
         /tark/tark_web/templates/mane_project.html
         /tark/tark_web/templates/navbar_include.html  
Dev link: https://dev-tark.ensembl.org/web/mane_project/

4. EA-803  - most recent release at top of table in Release Stats and Release Set pages
**Not a MANE ticket, but included in this PR, as it is a small fix**
Files modified: 
       /tark/release/models.py
       /tark/tark_web/templates/datatable_view_release_set.html
Dev links: 
       https://dev-tark.ensembl.org/web/datatable/release_set/
       https://dev-tark.ensembl.org/web/statistics/