### PR TITLE
remove hyperlinks for patch releases

### DIFF
--- a/tark/tark_web/templates/datatable_view_release_set.html
+++ b/tark/tark_web/templates/datatable_view_release_set.html
@@ -83,8 +83,12 @@ $(document).ready(function() {
   			{ "mData": "shortname",
   			   "mRender": function ( data, type, row ) {
   			    if(row["source"] == "Ensembl"){
+				    var patch_release = ["85", "84", "83", "82", "81", "79", "78", "76"];
+				    if (patch_release.includes(data)) {
+					    return  data ;
+				    }else{
                return  '<a target="_blank" href="http://e'+data+'.ensembl.org">' + data + '</a>' + '  <span class="glyphicon glyphicon-link" aria-hidden="true"></span>' ;
-               }else{
+               }}else{
                return  '<a target="_blank" href="https://www.ncbi.nlm.nih.gov/refseq/">' + data + '</a>' + '  <span class="glyphicon glyphicon-link" aria-hidden="true"></span>';
                 return data;
                }


### PR DESCRIPTION
In http://tark.ensembl.org/web/datatable/release_set/, clicking on the hyperlinks (in version column) of certain releases takes to a redirected page that says "The Ensembl Archive you tried to reach is not available. You can go to one of the other available archives:"
Remove the hyperlinks to these releases, namely: "85", "84", "83", "82", "81", "79", "78", "76"