### PR TITLE
:arrow_down: downgrade packages to fix python compatiblity

### DIFF
--- a/.github/workflows/dep_check.yml
+++ b/.github/workflows/dep_check.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@v2
 
       # Set up Python version
-      - name: Set up Python 3.7.6
+      - name: Set up Python 3.6.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.6
+          python-version: 3.6.8
 
       # Runs a set of commands installing Python dependencies using the runners shell (Run a multi-line script)
       - name: Install Python dependencies (Dev)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ Markdown==2.6.11
 MarkupSafe==2.1.0
 mysql-connector-python==8.0.28
 mysqlclient==2.1.0
-numpy==1.19.5
+numpy==1.21.0
 openapi-codec==1.3.2
 protobuf==3.19.4
 pyfaidx==0.6.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ coreschema==0.0.4
 coverage==6.2
 coveralls==3.3.1
 Django==2.2.27
-django-auto-prefetch==1.1.0
+django-auto-prefetch==1.0.0
 django-crispy-forms==1.7.0
 django-debug-toolbar==3.2.4
 django-filter==2.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ Markdown==2.6.11
 MarkupSafe==2.1.0
 mysql-connector-python==8.0.28
 mysqlclient==2.1.0
-numpy==1.21.0
+numpy==1.19.5
 openapi-codec==1.3.2
 protobuf==3.19.4
 pyfaidx==0.6.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==6.3.2
+coverage==6.2
 coveralls==3.3.1
 Django==2.2.27
 django-auto-prefetch==1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ idna==3.3
 itypes==1.2.0
 Jinja2==3.0.3
 Markdown==2.6.11
-MarkupSafe==2.1.0
+MarkupSafe==2.0.1
 mysql-connector-python==8.0.28
 mysqlclient==2.1.0
 numpy==1.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-filter==2.4.0
 django-crispy-forms==1.7.0
 django-rest-swagger==2.1.2
 mysqlclient
-numpy==1.19.5
+numpy==1.21.0
 biopython==1.70
 bcbio-gff==0.6.4
 wget

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-filter==2.4.0
 django-crispy-forms==1.7.0
 django-rest-swagger==2.1.2
 mysqlclient
-numpy==1.21.0
+numpy==1.19.5
 biopython==1.70
 bcbio-gff==0.6.4
 wget


### PR DESCRIPTION
- `numpy` version `1.21.0` is not compatible with the python version we're using.
- Same for: `coverage`, `MarkupSafe` and `django-auto-prefetch`