### PR TITLE
Add fixes for running all unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,8 @@ Check in the browsesr
 http://localhost:9000/
 ```
 
+Run all the tests in the package:
+```
+./manage.py test --settings=tark.settings.test
+```
+

--- a/tark/tark/fixtures/transcript_fixture.json
+++ b/tark/tark/fixtures/transcript_fixture.json
@@ -41,7 +41,8 @@
       "exon_set_checksum": "3544A9D62C65B3E08F9681E9D57582249B8DB38A",
       "transcript_checksum": "DC9C23CA5EBE25EBADB7B2795D8078467BA0DB36",
       "sequence": "4D4D31564C94294958B5803295CE321E19B30EF0",
-      "session": 21224
+      "session": 21224,
+      "biotype": "protein_coding"
     }
   },
   {

--- a/tark/tark/tests/__init__.py
+++ b/tark/tark/tests/__init__.py
@@ -1,0 +1,16 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""

--- a/tark/tark_web/fixtures/transcript.json
+++ b/tark/tark_web/fixtures/transcript.json
@@ -131,6 +131,7 @@
       "exon_set_checksum": "8",
       "transcript_checksum": "6",
       "sequence": null,
+      "biotype": "protein_coding",
       "session": 1
     }
   },

--- a/tark/transcript/tests/__init__.py
+++ b/tark/transcript/tests/__init__.py
@@ -1,0 +1,16 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""

--- a/tark/transcript/tests/test_transcript_diff.py
+++ b/tark/transcript/tests/test_transcript_diff.py
@@ -112,6 +112,7 @@ class TranscriptDiffTest(LiveServerTestCase):
                                                      'exon_set_checksum': '3800000000000000000000000000000000000000',
                                                      'transcript_checksum': '3600000000000000000000000000000000000000',
                                                      'sequence': None,
+                                                     'biotype': "protein_coding",
                                                      'transcript_release_set': {'assembly': 'GRCh38', 'shortname': '96',
                                                                                 'description': 'Ensembl release',
                                                                                 'release_date': '2019-04-09',
@@ -145,7 +146,9 @@ class TranscriptDiffTest(LiveServerTestCase):
                                                        'exon_set_checksum': '3800000000000000000000000000000000000000',
                                                        'transcript_checksum':
                                                            '3600000000000000000000000000000000000000',
-                                                       'sequence': None, 'transcript_release_set': {
+                                                       'sequence': None,
+                                                       'biotype': "protein_coding",
+                                                       'transcript_release_set': {
                                       'assembly': 'GRCh38', 'shortname': '96',
                                       'description': 'Ensembl release',
                                       'release_date': '2019-04-09', 'source': 'Ensembl'},


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-957

We should be running all the Tark tests before deploying.  This adds some changes to enable us to do that:

1. A README change with the command to run the tests.
2. I've added some init files to directories to mark them as Python packages.  Currently the fact that they are not packages means that they get ignored by the Django testrunner.
3. I added a `biotype` field to one of the test transcripts.  Currently the biotype field defaults to `None` causing `TranscriptDiffTest` to fail.

With these changes, `./manage.py test --settings=tark.settings.test` passes.