### PR TITLE
fix how tark displays transcript assembly version

### DIFF
--- a/tark/tark_web/templates/search_result.html
+++ b/tark/tark_web/templates/search_result.html
@@ -607,10 +607,10 @@
                             <td><input type="radio" name="transcript1"></td>
                             <td><input type="checkbox" name="transcript2"></td>
                             <td>
-                                <a href="/web/transcript_details/{{ result.stable_id }}.{{ result.stable_id_version }}/{{ search_identifier|urlencode }}">{{ result.stable_id }}.{{ result.stable_id_version }}</a>
+                                <a href="/web/transcript_details/{{ result.stable_id }}.{{ result.stable_id_version }}/{{ search_identifier|urlencode }}?assembly_name={{ result.transcript_release_set|get_values_as_list:'assembly' }}">{{ result.stable_id }}.{{ result.stable_id_version }}</a>
                             </td>
 
-                            <td><a href="/web/search/?identifier={{ result.genes|get_values_as_list:"name"}}">
+                            <td><a href="/web/search/?identifier={{ result.genes|get_values_as_list:'name'}}">
                                 {{ result.genes|get_values_as_list:"name"}}</a></td>
 
                             <!--assembly -->

--- a/tark/tark_web/views.py
+++ b/tark/tark_web/views.py
@@ -168,6 +168,7 @@ def search_home(request):
     if request.method == 'GET' and "identifier" in request.GET:
 
         search_identifier = request.GET['identifier']
+        
         if search_identifier is not None:
             # replace white space
             search_identifier = search_identifier.replace(" ", "")
@@ -398,11 +399,16 @@ def feature_diff(request, feature, from_release, to_release, direction="changed"
 def transcript_details(request, stable_id_with_version, search_identifier):
     host_url = ApiUtils.get_host_url(request)
 
+    # get assembly name
+    assembly_name = request.GET.get('assembly_name', None)
+
     # get transcript details
     query_url_details = "/api/transcript/stable_id_with_version/?stable_id_with_version=" + stable_id_with_version + \
+                        "&assembly_name=" + assembly_name + \
                         "&expand_all=true"
     
     response = requests.get(host_url + query_url_details)
+
     transcript_details = {}
     translation_stable_id = ""
     if response.status_code == 200:

--- a/tark/transcript/drf/filters.py
+++ b/tark/transcript/drf/filters.py
@@ -230,6 +230,7 @@ class TranscriptDetailFilterBackend(BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, view):
         identifier = request.query_params.get('stable_id_with_version', None)
+        assembly_name = request.query_params.get('assembly_name', None)
 
         # to support version search
         identifier_version = None
@@ -238,7 +239,12 @@ class TranscriptDetailFilterBackend(BaseFilterBackend):
 
         if identifier is not None and identifier_version is not None:
             queryset = queryset.filter(stable_id=identifier).filter(stable_id_version=str(identifier_version))
+            
+            if assembly_name:
+                queryset = queryset.select_related('assembly').filter(assembly__assembly_name=assembly_name)
+
             return queryset.distinct()
+
 
         return Transcript.objects.none()
 


### PR DESCRIPTION
When two transcript have these same stable id version but different assembly versions, Tark sometimes displays the wrong assembly version for the transcript.

See links below for an example
![search_result](https://github.com/Ensembl/tark/assets/158073413/311078c8-4f2f-44bb-a812-2223c6147593)

This is for version 38
![version_38](https://github.com/Ensembl/tark/assets/158073413/11d1bd6b-2fad-4262-bf71-87aee84eb430)

This is for version 37
![version_37](https://github.com/Ensembl/tark/assets/158073413/73bdb3e0-7bdc-41b9-af91-b7bd783bf038)

Both version show GRcH38 which is wrong. This PR fixes that.