### PR TITLE
fix to add transcript, exons, translations to gene API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ tmp
 migrations
 inspectdb
 *.py~
-
+local.py

--- a/tark/gene/drf/serializers.py
+++ b/tark/gene/drf/serializers.py
@@ -41,7 +41,8 @@ class HgncNameField(serializers.RelatedField):
 class GeneSerializer(SerializerMixin, serializers.ModelSerializer):
     MANY2ONE_SERIALIZER = {Gene.MANY2ONE_RELATED['ASSEMBLY']: AssemblySerializer,
                            Gene.MANY2ONE_RELATED['HGNC']: GeneNamesSerializer}
-    ONE2MANY_SERIALIZER = {Gene.ONE2MANY_RELATED['RELEASE_SET']: ReleaseSetSerializer}
+    ONE2MANY_SERIALIZER = {Gene.ONE2MANY_RELATED['RELEASE_SET']: ReleaseSetSerializer,
+                           Gene.ONE2MANY_RELATED['GENE_TRANSCRIPT']: "transcript.drf.serializers.TranscriptGeneSerializer"}
 
     assembly = AssemblyField(read_only=True)
     name = HgncNameField(read_only=True)

--- a/tark/gene/models.py
+++ b/tark/gene/models.py
@@ -24,7 +24,7 @@ from genenames.models import GeneNames
 
 class Gene(auto_prefetch.Model):
     MANY2ONE_RELATED = {'SESSION': 'session', 'ASSEMBLY': 'assembly', 'HGNC': 'name'}
-    ONE2MANY_RELATED = {'RELEASE_SET': 'gene_release_set'}
+    ONE2MANY_RELATED = {'RELEASE_SET': 'gene_release_set', 'GENE_TRANSCRIPT': 'transcripts'}
 
     gene_id = models.AutoField(primary_key=True)
     stable_id = models.CharField(max_length=64)

--- a/tark/tark/urls.py
+++ b/tark/tark/urls.py
@@ -15,7 +15,7 @@
    limitations under the License.
 """
 
-from django.urls.conf import include
+from django.urls.conf import include, path
 from rest_framework_swagger.views import get_swagger_view
 
 from django.conf.urls import url
@@ -71,6 +71,7 @@ urlpatterns = [
         name="privacy_notice_tark"),
     url(r'^robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain'),
         name="robots_file"),
+        # path("__debug__/", include("debug_toolbar.urls")),
 
 ]
 

--- a/tark/transcript/drf/serializers.py
+++ b/tark/transcript/drf/serializers.py
@@ -27,7 +27,7 @@ from release.models import TranscriptReleaseTag, \
 from transcript.models import Transcript
 from sequence.drf.serializers import SequenceSerializer
 from gene.drf.serializers import GeneSerializer
-from exon.drf.serializers import ExonTranscriptSerializer
+from exon.drf.serializers import ExonTranscriptSerializer, ExonSerializer
 from translation.drf.serializers import TranslationSerializer
 import json
 from tark.utils.exon_utils import ExonUtils
@@ -67,6 +67,21 @@ class TranscriptManeSerializer(serializers.Serializer):
     refseq_stable_id_version = serializers.CharField()
     mane_type = serializers.CharField()
     ens_gene_name = serializers.CharField()
+
+
+
+class TranscriptGeneSerializer(serializers.ModelSerializer):
+    assembly = AssemblyField(read_only=True)
+    exons = ExonSerializer(many=True)
+    translations = TranslationSerializer(many=True)
+
+    class Meta:
+        model = Transcript
+        fields = CommonFields.COMMON_FIELD_SET + ('exon_set_checksum', 'transcript_checksum',
+                                                  'exons', 'translations', 'biotype') + (
+            'three_prime_utr_start', 'three_prime_utr_end', 'three_prime_utr_seq', 'three_prime_utr_checksum',
+            'five_prime_utr_start', 'five_prime_utr_end', 'five_prime_utr_seq', 'five_prime_utr_checksum')
+
 
 
 class TranscriptSerializer(SerializerMixin, serializers.ModelSerializer):

--- a/tark/transcript/models.py
+++ b/tark/transcript/models.py
@@ -54,7 +54,7 @@ class Transcript(auto_prefetch.Model):
     transcript_release_set = models.ManyToManyField('release.ReleaseSet', through='release.TranscriptReleaseTag',
                                                     related_name='transcript_release_set')
     biotype = models.CharField(max_length=40, blank=True, null=True)
-    genes = models.ManyToManyField('gene.Gene', through='transcript.TranscriptGene')
+    genes = models.ManyToManyField('gene.Gene', through='transcript.TranscriptGene', related_name='transcripts')
     exons = models.ManyToManyField('exon.Exon', through='exon.ExonTranscript')
     translations = models.ManyToManyField('translation.Translation', through='translation.TranslationTranscript')
 


### PR DESCRIPTION
JIRA Tickets
[https://www.ebi.ac.uk/panda/jira/browse/EA-1186](EA1186)

Current Tark API does not display transcripts, exons, translations in the Gene API. This PR adds support for that. It also improves the number of queries sent to the database for each request. Before, 34 queries were being sent now, only 11 queries are sent. See example API request before and after the fix.

Before fix:
```
{
            "stable_id": "ENSG00000187003",
            "stable_id_version": 6,
            "assembly": {
                "assembly_id": 1,
                "assembly_name": "GRCh38",
                "genome": 1,
                "session": 1
            },
            "loc_start": 108862266,
            "loc_end": 108863759,
            "loc_strand": 1,
            "loc_region": "9",
            "loc_checksum": "4DC46F928E8535167DD4AFB20CCB6BAAD9A82DE0",
            "name": {
                "gene_names_id": 789,
                "external_id": "HGNC:161",
                "name": "ACTL7A",
                "source": "HGNC",
                "primary_id": 1,
                "session": 37271
            },
            "gene_checksum": "CBB6B5BA34E52178BD29EFA6D97648D5856B529A",
            "gene_release_set": [
                {
                    "assembly": "GRCh38",
                    "shortname": "76",
                    "description": "Ensembl release",
                    "release_date": "2014-05-01",
                    "source": "Ensembl"
                },
                {
                    "assembly": "GRCh38",
                    "shortname": "77",
                    "description": "Ensembl release",
                    "release_date": "2014-10-01",
                    "source": "Ensembl"
                },
               ...
                {
                    "assembly": "GRCh38",
                    "shortname": "97",
                    "description": "Ensembl release",
                    "release_date": "2019-07-29",
                    "source": "Ensembl"
                }
            ],
  }
```

After Fix
```
{
            "stable_id": "ENSG00000187003",
            "stable_id_version": 6,
            "assembly": {
                "assembly_id": 1,
                "assembly_name": "GRCh38",
                "genome": 1,
                "session": 1
            },
            "loc_start": 108862266,
            "loc_end": 108863759,
            "loc_strand": 1,
            "loc_region": "9",
            "loc_checksum": "4DC46F928E8535167DD4AFB20CCB6BAAD9A82DE0",
            "name": {
                "gene_names_id": 789,
                "external_id": "HGNC:161",
                "name": "ACTL7A",
                "source": "HGNC",
                "primary_id": 1,
                "session": 37271
            },
            "gene_checksum": "CBB6B5BA34E52178BD29EFA6D97648D5856B529A",
            "gene_release_set": [
                {
                    "assembly": "GRCh38",
                    "shortname": "76",
                    "description": "Ensembl release",
                    "release_date": "2014-05-01",
                    "source": "Ensembl"
                },
                {
                    "assembly": "GRCh38",
                    "shortname": "77",
                    "description": "Ensembl release",
                    "release_date": "2014-10-01",
                    "source": "Ensembl"
                },
                ...
                {
                    "assembly": "GRCh38",
                    "shortname": "97",
                    "description": "Ensembl release",
                    "release_date": "2019-07-29",
                    "source": "Ensembl"
                }
            ],
           "transcripts": [
                {
                    "stable_id": "ENST00000333999",
                    "stable_id_version": 4,
                    "assembly": "GRCh38",
                    "loc_start": 108862266,
                    "loc_end": 108863759,
                    "loc_strand": 1,
                    "loc_region": "9",
                    "loc_checksum": "4DC46F928E8535167DD4AFB20CCB6BAAD9A82DE0",
                    "exon_set_checksum": "C4A3D4BE01CE6E94C2F725AB0505301C06C7D29F",
                    "transcript_checksum": "61CA08C2DC5FB47A4538676F4AB66D4269218F93",
                    "exons": [
                        {
                            "stable_id": "ENSE00001332350",
                            "stable_id_version": 6,
                            "assembly": "GRCh38",
                            "loc_start": 108862266,
                            "loc_end": 108863759,
                            "loc_strand": 1,
                            "loc_region": "9",
                            "loc_checksum": "4DC46F928E8535167DD4AFB20CCB6BAAD9A82DE0",
                            "exon_checksum": "B7D7C4598CB0171442056CAA4818FE7A1B95CB09",
                            "sequence": "8B3A6AF6BD563B28CA7748003A9EE70D80C10A8B"
                        }
                    ],
                    "translations": [
                        {
                            "stable_id": "ENSP00000334300",
                            "stable_id_version": 3,
                            "assembly": "GRCh38",
                            "loc_start": 108862323,
                            "loc_end": 108863630,
                            "loc_strand": 1,
                            "loc_region": "9",
                            "loc_checksum": "EB9F6C2BF9BDDD3D3B7D9AAB8F685D165DC37967",
                            "translation_id": 1,
                            "translation_checksum": "DBF5112940ACF0201F54D9B032712B77F97738F4"
                        }
                    ],
                    "biotype": "protein_coding",
                    "three_prime_utr_start": 108863631,
                    "three_prime_utr_end": 108863759,
                    "three_prime_utr_seq": "ACAGCGACGAGGATGGACACTGCACTGGCAGTGCCTACCCTCGACAGGGTGAGCGCACTCCTACACACAGGGGGTGGAGCCGGCGCTTATTCCTGTAGCATTAAACACCCCTCATATGCCCCTCCACAG",
                    "three_prime_utr_checksum": "48C0CE71901F81475764CD124766FC777C07C6CB",
                    "five_prime_utr_start": 108862266,
                    "five_prime_utr_end": 108862322,
                    "five_prime_utr_seq": "AGGCCTTGAATCCAGTGGGATTGAGAACTTTCTAAGAGTGGTGCGGCTCTTGACAAC",
                    "five_prime_utr_checksum": "C778075C8A635B4057B34B1CBDABD994F9CB5DB2"
                }
            ]
        }
```

