### PR TITLE
[HOTFIX] Set `assembly_name` default value to empty string instead of None

### DIFF
--- a/tark/tark_web/views.py
+++ b/tark/tark_web/views.py
@@ -400,7 +400,7 @@ def transcript_details(request, stable_id_with_version, search_identifier):
     host_url = ApiUtils.get_host_url(request)
 
     # get assembly name
-    assembly_name = request.GET.get('assembly_name', None)
+    assembly_name = request.GET.get('assembly_name', '')
 
     # get transcript details
     query_url_details = "/api/transcript/stable_id_with_version/?stable_id_with_version=" + stable_id_with_version + \


### PR DESCRIPTION
Set `assembly_name` default value to empty string instead of `None`

This page for example https://tark.ensembl.org/web/transcript_details/ENST00000252934.10/ATXN10/ was throwing
> query_url_details = "/api/transcript/stable_id_with_version/?stable_id_with_version=" + stable_id_with_version + \
TypeError: can only concatenate str (not "NoneType") to str
[01/Jul/2024 12:38:05] "GET /web/transcript_details/ENST00000252934.10/ATXN10/ HTTP/1.1" 500 73665

because `assembly_name` was `None`.