### PR TITLE
Use primary HGNC names in search

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ Run all the tests in the package:
 ./manage.py test --settings=tark.settings.test
 ```
 
+### Using Docker
+
+To run the app using docker, build and then run the image
+```
+docker build -t tark_app .
+
+docker run -p 8000:8000 tark_app
+```

--- a/tark/tark_web/templates/search_result.html
+++ b/tark/tark_web/templates/search_result.html
@@ -41,13 +41,9 @@
             }
             transcript_release = transcript_releases_trimmed.sort().pop();
 
-            //removing e and r from release
-            if (transcript_release.startsWith("e")) {
-                transcript_release = transcript_release.substring(1, 4);
-                //console.log(' From e ' + transcript_release);
-            } else if (transcript_release.startsWith("r")) {
-                transcript_release = transcript_release.substring(1, 13);
-                //console.log('From r ' + transcript_release)
+            // Removing 'e' or 'r' from the start of transcript_release
+            if (transcript_release.startsWith("e") || transcript_release.startsWith("r")) {
+                transcript_release = transcript_release.substring(1);  // Skips the first character
             } else {
                 transcript_release = transcript_release.substring(0, 2);
             }
@@ -254,6 +250,7 @@
                 var source = payload_data_tr['transcript2_source'];
                 var release = payload_data_tr['transcript2_release'];
                 tr_result = get_tr_details(stable_id, stable_id_version, release, assembly, source);
+                console.log("tr_result --> ", tr_result)
                 transcript_container.push(tr_result);
             });
             return transcript_container;

--- a/tark/tark_web/templates/search_result.html
+++ b/tark/tark_web/templates/search_result.html
@@ -250,7 +250,6 @@
                 var source = payload_data_tr['transcript2_source'];
                 var release = payload_data_tr['transcript2_release'];
                 tr_result = get_tr_details(stable_id, stable_id_version, release, assembly, source);
-                console.log("tr_result --> ", tr_result)
                 transcript_container.push(tr_result);
             });
             return transcript_container;

--- a/tark/tark_web/templates/search_result.html
+++ b/tark/tark_web/templates/search_result.html
@@ -91,7 +91,7 @@
 
             document.getElementById('search_diff_transcript').scrollIntoView();
 
-            all_trancripts_details = get_all_transcript_details(payload_data_tr2_list);
+            var all_trancripts_details = get_all_transcript_details(payload_data_tr2_list);
 
 
             //get details for the first transcript
@@ -218,8 +218,8 @@
         }
 
         function get_tr_details(stable_id, stable_id_version, release, assembly, source) {
-            tr_results = {};
-            tr_url = "/api/transcript/?stable_id=" + stable_id + "&stable_id_version=" + stable_id_version + "&release_short_name=" + release + "&assembly_name=" + assembly + "&source_name=" + source + "&expand_all=true";
+            var tr_results = {};
+            var tr_url = "/api/transcript/?stable_id=" + stable_id + "&stable_id_version=" + stable_id_version + "&release_short_name=" + release + "&assembly_name=" + assembly + "&source_name=" + source + "&expand_all=true";
             $.ajax({
                 url: tr_url,
                 type: 'GET',

--- a/tark/transcript/drf/filters.py
+++ b/tark/transcript/drf/filters.py
@@ -215,7 +215,14 @@ class TranscriptSearchFilterBackend(BaseFilterBackend):
             elif identifier_type == SearchUtils.LRG_GENE:
                 queryset = queryset.filter(genes__stable_id__exact=identifier)
             elif identifier_type == SearchUtils.HGNC_SYMBOL:
-                queryset = queryset.filter(genes__name__name__exact=identifier)
+                # restrict the gene name search to primary names from source
+                # type HGNC. There's code in tark/fields.py that purports to do
+                # this but it doesn't seem to be working.
+                queryset = queryset.filter(
+                    genes__name__name__exact=identifier,
+                    genes__name__primary_id__exact=1,
+                    genes__name__source__exact='HGNC'
+                )
 
         return queryset.distinct()
 


### PR DESCRIPTION
Searching for a gene name in the live tark website or the dev site returns transcripts for genes with synonyms matching the intended gene. For example, searching for HK1 returns results for HOOK1 and KCNA4, both of which list HK1 as a synonym. The search query should restrict results to primary names (which excludes synonyms).

There's code in the application that purports to restrict searches to primary names from source "HGNC", but it seems to be ancient django magic that doesn't get triggered by a normal search. This PR explicitly adds filters for primary names and HGNC source.

See [EA-1260](https://www.ebi.ac.uk/panda/jira/browse/EA-1260).

This fix has been tested locally in docker but it needs to be deployed on a VM and tested more widely.