### PR TITLE
fix to unrecognised transcript id

### DIFF
--- a/tark/tark_web/templates/transcript_id_not_found.html
+++ b/tark/tark_web/templates/transcript_id_not_found.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}Tark home{% endblock %}
+
+{% load static %}
+
+{% block header %}
+
+    {% include "navbar_include.html" with show_rest="true" %}
+
+{% endblock %}
+
+
+
+{% block content %}
+    <div class="container">
+
+        <p style="padding-top:40px;"></p>
+
+        <p style="font-weight: bold; font-size: 2rem; color: red">The stable id {{stable_id_with_version}} has no version. Please include the version as it is needed to find the transcript.</p>
+
+        {% include "search_big_box.html" %}
+
+{% endblock %}

--- a/tark/tark_web/views.py
+++ b/tark/tark_web/views.py
@@ -399,6 +399,11 @@ def feature_diff(request, feature, from_release, to_release, direction="changed"
 def transcript_details(request, stable_id_with_version, search_identifier):
     host_url = ApiUtils.get_host_url(request)
 
+    has_stable_id_version = len(stable_id_with_version.split(".")) > 1
+
+    if not has_stable_id_version:
+        return render(request, 'transcript_id_not_found.html', context={'stable_id_with_version': stable_id_with_version})
+
     # get assembly name
     assembly_name = request.GET.get('assembly_name', '')
 


### PR DESCRIPTION
Tark currently has the issue such that If the version number from a transcript ID in a valid URL is removed, we get a broken page rather than a proper error page.
The image below shows the broken page:
![image](https://github.com/user-attachments/assets/efff1806-89a9-4a15-abbc-600e8f30febd)

This PR add a page that shows the correct error to the user, here is an example below

![image](https://github.com/user-attachments/assets/5dd6ce4f-fbb7-469b-b2da-bed94ec91dce)
