### PR TITLE
fixed error  with transcript details page

### DIFF
--- a/tark/tark_web/templates/transcript_search_identifier_not_found.html
+++ b/tark/tark_web/templates/transcript_search_identifier_not_found.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}Tark home{% endblock %}
+
+{% load static %}
+
+{% block header %}
+
+    {% include "navbar_include.html" with show_rest="true" %}
+
+{% endblock %}
+
+
+
+{% block content %}
+    <div class="container">
+
+        <p style="padding-top:40px;"></p>
+
+        <p style="font-weight: bold; font-size: 2rem; color: red">The requested page could not be found because of a malformed url. Please construct the url correctly.</p>
+        <p style="font-weight: bold; font-size: 2rem; color: red">Example: https://tark.ensembl.org/web/transcript_details/stable_id_with_version/stable_id_with_version/</p>
+
+        {% include "search_big_box.html" %}
+
+{% endblock %}

--- a/tark/tark_web/views.py
+++ b/tark/tark_web/views.py
@@ -396,13 +396,16 @@ def feature_diff(request, feature, from_release, to_release, direction="changed"
     )
 
 
-def transcript_details(request, stable_id_with_version, search_identifier):
+def transcript_details(request, stable_id_with_version, search_identifier=""):
     host_url = ApiUtils.get_host_url(request)
 
     has_stable_id_version = len(stable_id_with_version.split(".")) > 1
 
     if not has_stable_id_version:
         return render(request, 'transcript_id_not_found.html', context={'stable_id_with_version': stable_id_with_version})
+
+    if not search_identifier:
+        return render(request, 'transcript_search_identifier_not_found.html')
 
     # get assembly name
     assembly_name = request.GET.get('assembly_name', '')


### PR DESCRIPTION
This PR helps with the following error:
When visiting the following page:
https://tark.ensembl.org/web/transcript_details/NM_013236.4/
It throws a 500 error. This is caused by the search_identifier by not being passed in the url.
To fix this issue, this PR adds a condition to the Django view to check for the existence of the search_identifier. If it is not there, a 404 page is shown to the user.